### PR TITLE
wasm: export symbols

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -25,12 +25,22 @@ pub fn build(b: *std.Build) !void {
     const target_wasm = if (target.cpu_arch) |arch| arch.isWasm() else false;
     const demo = init: {
         if (target_wasm) {
-            break :init b.addSharedLibrary(.{
+            const lib = b.addSharedLibrary(.{
                 .name = "demo",
                 .root_source_file = .{ .path = "examples/example_wasm.zig" },
                 .target = target,
                 .optimize = optimize,
             });
+            // lib.import_table = true;
+            lib.bundle_compiler_rt = true;
+            lib.export_symbol_names = &.{
+                "onInit",
+                "onResize",
+                "onKeyDown",
+                "onMouseMove",
+                "onAnimationFrame",
+            };
+            break :init lib;
         } else {
             break :init b.addExecutable(.{
                 .name = "demo",


### PR DESCRIPTION
I made this change long ago.

I think there was the problem of generated wasm file has no exported symbols. Not sure if it is still a problem now.