### PR TITLE
changes for "isDarwin()", changes to build.zig.zon

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -15,7 +15,7 @@ pub fn build(b: *std.Build) !void {
     nanovg_mod.addCSourceFile(.{ .file = b.path("src/fontstash.c"), .flags = &.{ "-DFONS_NO_STDIO", "-fno-stack-protector" } });
     nanovg_mod.addCSourceFile(.{ .file = b.path("src/stb_image.c"), .flags = &.{ "-DSTBI_NO_STDIO", "-fno-stack-protector" } });
 
-    if (target.result.isWasm()) {
+    if (target.result.cpu.arch.isWasm()) {
         const demo_wasm = installDemo(b, target, optimize, "demo", "examples/example_wasm.zig", nanovg_mod);
         demo_wasm.addIncludePath(b.path("examples"));
         demo_wasm.addCSourceFile(.{ .file = b.path("examples/stb_image_write.c"), .flags = &.{ "-DSTBI_NO_STDIO", "-fno-stack-protector" } });
@@ -42,7 +42,7 @@ fn installDemo(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.bu
     });
     demo.root_module.addImport("nanovg", nanovg_mod);
 
-    if (target.result.isWasm()) {
+    if (target.result.cpu.arch.isWasm()) {
         demo.rdynamic = true;
         demo.entry = .disabled;
     } else {

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
-    .name = "nanovg-zig",
-
+    .name = .nanovg_zig,
     .version = "0.0.0",
+    .fingerprint = 0x84abd4315eb3f875,
 
     // This field is optional.
     // This is currently advisory only; Zig does not yet do anything

--- a/examples/example_blur.zig
+++ b/examples/example_blur.zig
@@ -52,7 +52,7 @@ pub fn main() !void {
 
     const monitor = c.glfwGetPrimaryMonitor();
     var scale: f32 = 1;
-    if (!builtin.target.isDarwin()) {
+    if (!builtin.target.os.tag.isDarwin()) {
         c.glfwGetMonitorContentScale(monitor, &scale, null);
     }
     window = c.glfwCreateWindow(@as(i32, @intFromFloat(scale * 1000)), @as(i32, @intFromFloat(scale * 600)), "NanoVG", null, null);

--- a/examples/example_clip.zig
+++ b/examples/example_clip.zig
@@ -199,7 +199,7 @@ pub fn main() !void {
 
     const monitor = c.glfwGetPrimaryMonitor();
     var scale: f32 = 1;
-    if (!builtin.target.isDarwin()) {
+    if (!builtin.target.os.tag.isDarwin()) {
         c.glfwGetMonitorContentScale(monitor, &scale, null);
     }
     window = c.glfwCreateWindow(@as(i32, @intFromFloat(scale * 1000)), @as(i32, @intFromFloat(scale * 600)), "NanoVG", null, null);

--- a/examples/example_fbo.zig
+++ b/examples/example_fbo.zig
@@ -70,7 +70,7 @@ pub fn main() !void {
 
     const monitor = c.glfwGetPrimaryMonitor();
     var scale: f32 = 1;
-    if (!builtin.target.isDarwin()) {
+    if (!builtin.target.os.tag.isDarwin()) {
         c.glfwGetMonitorContentScale(monitor, &scale, null);
     }
     window = c.glfwCreateWindow(@as(i32, @intFromFloat(scale * 1000)), @as(i32, @intFromFloat(scale * 600)), "NanoVG", null, null);

--- a/examples/example_glfw.zig
+++ b/examples/example_glfw.zig
@@ -45,7 +45,7 @@ pub fn main() !void {
 
     const monitor = c.glfwGetPrimaryMonitor();
     var scale: f32 = 1;
-    if (!builtin.target.isDarwin()) {
+    if (!builtin.target.os.tag.isDarwin()) {
         c.glfwGetMonitorContentScale(monitor, &scale, null);
     }
     window = c.glfwCreateWindow(@as(i32, @intFromFloat(scale * 1000)), @as(i32, @intFromFloat(scale * 600)), "NanoVG", null, null);

--- a/src/internal.zig
+++ b/src/internal.zig
@@ -122,7 +122,7 @@ pub const Context = struct {
     }
 
     pub fn restore(ctx: *Context) void {
-        _ = ctx.states.popOrNull();
+        _ = ctx.states.pop();
     }
 
     pub fn reset(ctx: *Context) void {


### PR DESCRIPTION
Just a few small changes needed to get nanovg-zig to compile on latest master.

One thing I was unsure about:  it appears that a dash ("-") is not accepted as a .name field in build.zig.zon.  When using .name = .nanovg-zig we receive an error of "expected enum literal".  So, to workaround this, an underscore was used instead of a dash.